### PR TITLE
Fix the function dismiss does not correctly apply container animation

### DIFF
--- a/Sources/SwiftUIOverlayContainer/Container/QueueHandler.swift
+++ b/Sources/SwiftUIOverlayContainer/Container/QueueHandler.swift
@@ -125,7 +125,7 @@ extension ContainerQueueHandler {
         var animation = Animation.disable
         if flag {
             animation = Animation.merge(
-                containerAnimation: animation,
+                containerAnimation: self.animation,
                 viewAnimation: identifiableView.configuration.animation
             )
         }


### PR DESCRIPTION
`ContainerQueueHandler` 的 `dismiss` 方法在 `ContainerView` 未设置 `Animation` 时应当使用` Container` 设置的 `Animation`