### PR TITLE
Add configuration of security zones for background control

### DIFF
--- a/.swiftpm/xcode/xcuserdata/yadmin.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/.swiftpm/xcode/xcuserdata/yadmin.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>SwiftUIOverlayContainer.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>2</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Demo/Demo.xcodeproj/xcuserdata/yadmin.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Demo/Demo.xcodeproj/xcuserdata/yadmin.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>Demo (iOS).xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+		<key>Demo (macOS).xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Demo/Shared/Demos/BackgroundDemo.swift
+++ b/Demo/Shared/Demos/BackgroundDemo.swift
@@ -15,6 +15,7 @@ import SwiftUIOverlayContainer
 struct BackgroundDemo: View {
     @Environment(\.overlayContainerManager) var manager
     @State var tapToDismiss = true
+    
     var body: some View {
         ZStack {
             Color.clear
@@ -26,6 +27,7 @@ struct BackgroundDemo: View {
                                 tapToDismiss: tapToDismiss,
                                 backgroundStyle: background.background
                             )
+                            
                             let size = CGSize(width: 300, height: 400)
                             let view = BlockView(size: size, text: background.description, opacity: 1, allowDismiss: false)
                             manager.show(view: view, in: "backgroundContainer", using: viewConfiguration)
@@ -97,6 +99,7 @@ struct BackgroundContainerConfiguration: ContainerConfigurationProtocol {
     var queueType: ContainerViewQueueType { .oneByOne }
     var alignment: Alignment? { .center }
     var transition: AnyTransition? { .scale.combined(with: .opacity) }
+    var bgIgnoresSafeArea: ContainerIgnoresSafeArea { .all}
     var dismissGesture: ContainerViewDismissGesture? {
         .tap
     }
@@ -104,6 +107,8 @@ struct BackgroundContainerConfiguration: ContainerConfigurationProtocol {
     var shadowStyle: ContainerViewShadowStyle? {
         .radius(10)
     }
+    
+    
 }
 
 struct BackgroundDemoViewConfiguration: ContainerViewConfigurationProtocol {

--- a/Demo/Shared/en.lproj/Localizable.strings
+++ b/Demo/Shared/en.lproj/Localizable.strings
@@ -68,7 +68,7 @@
 "DisableBackground" = "No background";
 "ViewBackgroundDescription" = "When using material type as background, only iOS 15, macOS 12, tvOS 15 and above are supported. TapToDismiss will be ignored when no background is used.\nIn vertical and horizontal modes, the container will use its own background configuration and ignore the view's background settings.";
 "TapToDismiss" = "Tap on the background to dismiss the view";
-
+"BgIgnoresSafeArea" = "Background Cancel Security Zone";
 
 // MARK: - Bind Demo
 

--- a/Demo/Shared/zh-Hans.lproj/Localizable.strings
+++ b/Demo/Shared/zh-Hans.lproj/Localizable.strings
@@ -68,7 +68,7 @@
 "DisableBackground" = "不添加背景";
 "ViewBackgroundDescription" = "当使用材料类型作为背景时，只支持iOS 15、macOS 12、tvOS 15及以上版本。当没有使用背景时，TapToDismiss将被忽略。在垂直和水平模式下，将忽略视图的背景设置，使用容器的背景配置。";
 "TapToDismiss" = "点击背景取消视图";
-
+"BgIgnoresSafeArea" = "背景取消安全区域";
 
 // MARK: - Bind Demo
 

--- a/Sources/SwiftUIOverlayContainer/Container/CompositeContainerView.swift
+++ b/Sources/SwiftUIOverlayContainer/Container/CompositeContainerView.swift
@@ -175,6 +175,7 @@ extension OverlayContainer {
             // the current context of view is ZStack (GenericStack)
             backgroundOfIdentifiableView
                 .zIndex(timeStamp: identifiableView.timeStamp, order: containerConfiguration.displayOrder, background: true)
+                .ignoresSafeArea(type: containerConfiguration.bgIgnoresSafeArea)
             compositingView
                 .padding(containerConfiguration.insets) // add insets for each view
                 .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: alignment)

--- a/Sources/SwiftUIOverlayContainer/Container/Container.swift
+++ b/Sources/SwiftUIOverlayContainer/Container/Container.swift
@@ -141,6 +141,7 @@ struct OverlayContainer: View {
                     background
                         .opacity(queueHandler.mainQueue.isEmpty ? 0 : 1)
                         .zIndex(1.0)
+                        .ignoresSafeArea(type: configuration.bgIgnoresSafeArea)
 
                     GenericStack(displayType: configuration.displayType, alignment: alignment, spacing: configuration.spacing) {
                         ForEach(queueHandler.mainQueue.alignment(

--- a/Sources/SwiftUIOverlayContainer/Container/ContainerProtocols.swift
+++ b/Sources/SwiftUIOverlayContainer/Container/ContainerProtocols.swift
@@ -68,6 +68,11 @@ public protocol ContainerCompositionProtocol {
     /// Default value is disable
     var ignoresSafeArea: ContainerIgnoresSafeArea { get }
 
+    /// Expands the backgroud container out of its safe area.
+    ///
+    /// Default value is disable
+    var bgIgnoresSafeArea: ContainerIgnoresSafeArea { get }
+    
     /// Controls the display order of overlapping views.
     ///
     /// Default value is ascending order, new container view can overlap the old one
@@ -97,7 +102,9 @@ public extension ContainerCompositionProtocol {
     var clipped: Bool { false }
 
     var ignoresSafeArea: ContainerIgnoresSafeArea { .disable }
-
+    
+    var bgIgnoresSafeArea: ContainerIgnoresSafeArea { .disable }
+    
     var displayOrder: ContainerDisplayOrder { .ascending }
 }
 


### PR DESCRIPTION
When setting a security area that only requires the background container, the background can be independently controlled by adding a new configuration (bgIgnoresSafeArea) without affecting the parent container